### PR TITLE
Include sh file types to the indentation block

### DIFF
--- a/config/vim/.vimrc
+++ b/config/vim/.vimrc
@@ -11,8 +11,8 @@ set number
 
 augroup filetype_indentation
   autocmd!
-  " Zsh files: 2 spaces
-  autocmd FileType zsh setlocal tabstop=2 shiftwidth=2 softtabstop=2 expandtab
+  " Shell files: 2 spaces
+  autocmd FileType sh,zsh setlocal tabstop=2 shiftwidth=2 softtabstop=2 expandtab
 
   " Python files: 4 spaces
   autocmd FileType python setlocal tabstop=4 shiftwidth=4 softtabstop=4 expandtab


### PR DESCRIPTION
#Resolves 51

We want to have consistent spacing and indentation rules across all shell scripts, so we added posix compatible shell scripts (sh) to the shell files group in vimrc
